### PR TITLE
Sign compare fixes and fix example code 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(modbuspp)
 set(CMAKE_CXX_STANDARD 11)
-
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror")
 set(SOURCE_FILES example.cpp)
 include_directories(./)
 

--- a/example.cpp
+++ b/example.cpp
@@ -59,6 +59,5 @@ int main(int argc, char **argv)
 
     // close connection and free the memory
     mb.modbus_close();
-    delete(&mb);
     return 0;
 }


### PR DESCRIPTION
`amount` and `address` parameters were int and needlessly bounds checked to ensure they were within the range of a 16-bit unsigned integer (they were also missing negative bounds checking). I switched these to uint16_t and removed that needless bounds checking. 

There was also a deletion of a non-heap object in the example that is fixed in this PR. 